### PR TITLE
Speedup marker calculation and reduce DOM nodes

### DIFF
--- a/demo/demo.html
+++ b/demo/demo.html
@@ -67,7 +67,7 @@
             className: 'marker'
         });
         var i, markerArr = [];
-        for (i = 0; i < 5000; i++) {
+        for (i = 0; i < 100000; i++) {
             markerArr.push(L.marker([markers[i][1], markers[i][0]], {
                 icon: markerIcon,
                 isAdvertizing: Math.random() < 0.01
@@ -84,7 +84,8 @@
 //                return minimumLevel;
             },
             minZoom: 8,
-            maxZoom: 18
+            maxZoom: 18,
+            viewportHideOffset: 1
         });
         var testMarker = L.marker([55.011216355382, 82.874299953485], {icon: markerIcon, count:0});
 //    testMarker.showAlways = true;

--- a/dist/generalize.src.js
+++ b/dist/generalize.src.js
@@ -640,13 +640,13 @@ L.Util.extend(L.MarkerClassList.prototype, {
         return !!this._classList[className];
     },
     clear: function() {
+        this._classList = {};
         if (!this._marker._icon) {
             return;
         }
         for (var className in this._classList) {
             L.DomUtil.removeClass(this._marker._icon, className);
         }
-        this._classList = {};
     },
     toString: function() {
         if (Object.keys) {
@@ -883,6 +883,7 @@ L.MarkerGeneralizeGroup = L.FeatureGroup.extend({
 
         var oldMap = this._map;
 
+        // Don't allow markers to be added to map: we'll do it during invalidation.
         if (oldMap) {
             this._map = null;
         }

--- a/dist/generalize.src.js
+++ b/dist/generalize.src.js
@@ -684,10 +684,6 @@ L.MarkerEx = L.Marker.extend({
      */
     _extended: true,
 
-    /**
-     * Do not consider this marker in generalization
-     */
-    _generalizationImmune: false,
 
     /**
      * Augment parent method to apply class names when icon is added on map
@@ -711,7 +707,6 @@ L.MarkerEx = L.Marker.extend({
         if (this._immunityLevel == this.IMMUNITY.NO_HIDE) {
             return false;
         }
-
         if (this._immunityLevel == this.IMMUNITY.NO_DELETE) {
             this._icon.style.display = 'none';
             return false;
@@ -745,9 +740,6 @@ L.MarkerEx = L.Marker.extend({
     revokeImmunity: function() {
         this._immunityLevel = this.IMMUNITY.NONE;
         return this;
-    },
-    generalizationImmunity: function() {
-        this._generalizationImmune = true;
     }
 });
 
@@ -984,7 +976,7 @@ L.MarkerGeneralizeGroup = L.FeatureGroup.extend({
 
         for (i = 0; i < this._otherMarkers.length; i++) {
             currentMarker = this._otherMarkers[i];
-            if (currentMarker._generalizationImmune) {
+            if (currentMarker._immunityLevel) {
                 continue;
             }
             seekMarkers.push(currentMarker);

--- a/dist/generalize.src.js
+++ b/dist/generalize.src.js
@@ -744,7 +744,15 @@ L.MarkerGeneralizeGroup = L.FeatureGroup.extend({
             this._otherMarkers.push(layer);
         }
 
+        var oldMap = this._map;
+
+        if (oldMap) {
+            this._map = null;
+        }
         L.LayerGroup.prototype.addLayer.call(this, layer);
+        if (oldMap) {
+            this._map = oldMap;
+        }
     },
 
     _prepareMarker: function(layer) {
@@ -757,7 +765,8 @@ L.MarkerGeneralizeGroup = L.FeatureGroup.extend({
 
     _setMarkerPosition: function(layer, zoom) {
         layer._positions[zoom] = this._map.project(layer.getLatLng(), zoom); // calculate pixel position
-        layer.options.classForZoom = [];
+        layer.options.classForZoom = layer.options.classForZoom || [];
+        layer.options.classForZoom[zoom] = 'HIDDEN';
     },
 
     _calculateMarkersClassForEachZoom: function() {
@@ -819,67 +828,50 @@ L.MarkerGeneralizeGroup = L.FeatureGroup.extend({
         currentLevel = levels[0];
 
         for (i = 0; i < this._priorityMarkers.length; i++) {
-            currentMarker = this._prepareMarker(i);
+            currentMarker = this._prepareMarker(this._priorityMarkers[i]);
             tmpMarkers[currentLevel].push(currentMarker);
             tree.insert(makeNode(currentMarker, currentLevel));
         }
 
-        var items, pendingMarkers = [],
+        var items,
             seekMarkers = this._otherMarkers.slice();
 
-        L.Util.UnblockingFor(processAllMarkers, levels.length, updateMarkerStyles);
+        L.Util.UnblockingFor(processAllMarkers, levels.length, zoomReady);
 
         function processAllMarkers(levelIndex, levelsCallback) {
+            var pendingMarkers = [];
+            var totalMarkesCount = seekMarkers.length;
             currentLevel = levels[levelIndex];
 
             if (levels[levelIndex].size[0] == 0 && levels[levelIndex].size[1] == 0) {
-                tmpMarkers[levelIndex] = seekMarkers.slice();
                 levelsCallback();
                 return;
             }
 
-            var markersInBucket = 1000;
-            var totalMarkesCount = seekMarkers.length;
-            var iterationsCount = Math.ceil(totalMarkesCount / markersInBucket);
+            for (var i = 0; i < totalMarkesCount; i++) {
+                var currentMarker = seekMarkers[i];
 
-            L.Util.UnblockingFor(processBucket, iterationsCount, onBucketFinish);
+                if (that.options.checkMarkerMinimumLevel(currentMarker) <= levelIndex) {
+                    var node = makeNode(currentMarker, currentLevel);
+                    items = tree.search(node);
 
-            function processBucket(bucketIndex, markersCallback) {
-                for (var i = markersInBucket * bucketIndex; i < markersInBucket * (bucketIndex + 1) && i < totalMarkesCount; i++) {
-                    if (that.options.checkMarkerMinimumLevel(seekMarkers[i]) <= levelIndex) {
-                        currentMarker = makeNode(seekMarkers[i], currentLevel);
-                        items = tree.search(currentMarker);
-
-                        if (that._validateGroup(currentMarker, items)) {
-                            tree.insert(currentMarker);
-                            tmpMarkers[levelIndex].push(seekMarkers[i]);
-                        } else {
-                            pendingMarkers.push(seekMarkers[i]);
-                        }
+                    if (that._validateGroup(node, items)) {
+                        tree.insert(node);
+                        currentMarker.options.classForZoom[zoom] = currentLevel.className;
+                        tmpMarkers[levelIndex].push(currentMarker);
                     } else {
-                        pendingMarkers.push(seekMarkers[i]);
+                        pendingMarkers.push(currentMarker);
                     }
+                } else {
+                    pendingMarkers.push(currentMarker);
                 }
-                markersCallback();
             }
 
-            function onBucketFinish() {
-                seekMarkers = pendingMarkers.slice();
-                pendingMarkers = [];
-                levelsCallback();
-            }
+            seekMarkers = pendingMarkers.slice();
+            levelsCallback();
         }
 
-        function updateMarkerStyles() {
-            var groupInd, markerInd, group, groupClass, currMarker;
-            for (groupInd = 0; groupInd < levels.length; groupInd++) {
-                groupClass = levels[groupInd].className;
-                group = levels[groupInd];
-                for (markerInd = 0; markerInd < tmpMarkers[groupInd].length; markerInd++) {
-                    currMarker = tmpMarkers[groupInd][markerInd];
-                    currMarker.options.classForZoom[zoom] = groupClass;
-                }
-            }
+        function zoomReady() {
             that._zoomReady[zoom] = true;
             // if finish calculate styles for current level
             if (that._map.getZoom() == zoom) that._invalidateMarkers();
@@ -974,54 +966,52 @@ L.MarkerGeneralizeGroup = L.FeatureGroup.extend({
      * @private
      */
     _invalidateMarkers: function() {
-        var groupClass, zoom = this._map.getZoom();
+        var zoom = this._map.getZoom();
 
         if (!this._zoomReady[zoom]) return;
 
+        var pixelBounds = this._map.getPixelBounds();
+        var width = (pixelBounds.max.x - pixelBounds.min.x) * this.options.viewportHideOffset;
+        var height = (pixelBounds.max.y - pixelBounds.min.y) * this.options.viewportHideOffset;
+
+        pixelBounds.min._subtract({x: width, y: height});
+        pixelBounds.max._add({x: width, y: height});
+
         this.eachLayer(function(marker) {
-            groupClass = marker.options.classForZoom[zoom];
-            if (!groupClass) return; //not ready yet
-            if (marker.options.state != groupClass) {
-                if (marker.options.state) {
-                    L.DomUtil.removeClass(marker._icon, marker.options.state);
+            var groupClass = marker.options.classForZoom[zoom];
+            var markerPos = marker._positions[zoom];
+            var markerState = marker.options.state;
+
+            // if marker in viewport
+            if (pixelBounds.contains(markerPos)) {
+                if (groupClass != 'HIDDEN' && markerState != groupClass) {
+                    if (!marker._map) {
+                        this._map.addLayer(marker);
+                    }
+
+                    if (markerState != groupClass) {
+                        if (markerState && markerState != 'HIDDEN') {
+                            L.DomUtil.removeClass(marker._icon, markerState);
+                        }
+                        L.DomUtil.addClass(marker._icon, groupClass);
+                    }
                 }
-                L.DomUtil.addClass(marker._icon, groupClass);
-                marker.options.state = groupClass;
+            } else {
+                groupClass = 'HIDDEN';
             }
+
+            if (groupClass == 'HIDDEN' && marker._map) {
+                this._map.removeLayer(marker);
+            }
+
+            marker.options.state = groupClass;
         }, this);
 
         this.fireEvent('invalidationFinish');
     },
 
-    _hideMarkersOutOfViewPort: function() {
-        var currentZoom = this._map.getZoom();
-        var pixelBounds = this._map.getPixelBounds();
-        var width = (pixelBounds.max.x - pixelBounds.min.x) * this.options.viewportHideOffset;
-        var height = (pixelBounds.max.y - pixelBounds.min.y) * this.options.viewportHideOffset;
-        this.eachLayer(function(marker) {
-            var markerPos = marker._positions[currentZoom];
-            if (markerPos.x > pixelBounds.min.x - width &&
-                markerPos.x < pixelBounds.max.x + width &&
-                markerPos.y > pixelBounds.min.y - height &&
-                markerPos.y < pixelBounds.max.y + height) {
-                marker._icon.style.display = '';
-            } else {
-                marker._icon.style.display = 'none';
-            }
-        });
-    },
-
     _zoomStart: function() {
         this.getPane().style.display = 'none';
-    },
-
-    _zoomEnd: function() {
-        this._invalidateMarkers();
-        this._hideMarkersOutOfViewPort();
-    },
-
-    _moveEnd: function() {
-        this._hideMarkersOutOfViewPort();
     },
 
     addLayer: function(layer) {
@@ -1042,7 +1032,7 @@ L.MarkerGeneralizeGroup = L.FeatureGroup.extend({
 
         if (this._map) {
             this.eachLayer(this._prepareMarker, this);
-            this._calculateMarkersClassForEachZoom();
+            setTimeout(this._calculateMarkersClassForEachZoom.bind(this), 0);
         }
         return this;
     },
@@ -1062,32 +1052,32 @@ L.MarkerGeneralizeGroup = L.FeatureGroup.extend({
         return this;
     },
 
+    getEvents: function() {
+        var events = {
+            zoomstart: this._zoomStart,
+            moveend: this._invalidateMarkers
+        };
+
+        return events;
+    },
+
     onAdd: function(map) {
         this._map = map;
-
-        map.on('zoomstart', this._zoomStart, this);
-        map.on('zoomend', this._zoomEnd, this);
-        map.on('moveend', this._moveEnd, this);
 
         if (this.getLayers().length) {
             this.eachLayer(this._prepareMarker, this);
             // wait user map manipulation to know correct init zoom
             setTimeout(this._calculateMarkersClassForEachZoom.bind(this), 0);
         }
-
-        L.LayerGroup.prototype.onAdd.call(this, map);
     },
 
     onRemove: function(map) {
         if (!this._map) return;
-        map.off('zoomstart', this._zoomStart, this);
-        map.off('zoomend', this._zoomEnd, this);
-        map.off('moveend', this._moveEnd, this);
 
         L.LayerGroup.prototype.onRemove.call(this, map);
 
         this.eachLayer(function(marker) {
-            marker.options.state = '';
+            marker.options.state = 'HIDDEN';
         });
 
         this._map = null;

--- a/dist/generalize.src.js
+++ b/dist/generalize.src.js
@@ -685,6 +685,11 @@ L.MarkerEx = L.Marker.extend({
     _extended: true,
 
     /**
+     * Do not consider this marker in generalization
+     */
+    _generalizationImmune: false,
+
+    /**
      * Augment parent method to apply class names when icon is added on map
      * @param map
      */
@@ -740,6 +745,9 @@ L.MarkerEx = L.Marker.extend({
     revokeImmunity: function() {
         this._immunityLevel = this.IMMUNITY.NONE;
         return this;
+    },
+    generalizationImmunity: function() {
+        this._generalizationImmune = true;
     }
 });
 
@@ -972,7 +980,15 @@ L.MarkerGeneralizeGroup = L.FeatureGroup.extend({
         }
 
         var items,
-            seekMarkers = this._otherMarkers.slice();
+            seekMarkers = [];
+
+        for (i = 0; i < this._otherMarkers.length; i++) {
+            currentMarker = this._otherMarkers[i];
+            if (currentMarker._generalizationImmune) {
+                continue;
+            }
+            seekMarkers.push(currentMarker);
+        }
 
         L.Util.UnblockingFor(processAllMarkers, levels.length, zoomReady);
 

--- a/dist/generalize.src.js
+++ b/dist/generalize.src.js
@@ -981,15 +981,22 @@ L.MarkerGeneralizeGroup = L.FeatureGroup.extend({
             var groupClass = marker.options.classForZoom[zoom];
             var markerPos = marker._positions[zoom];
             var markerState = marker.options.state;
+            // Immunity levels
+            var persistMarkerNode = marker._icon && marker.data.immunityLevel == 'doNotDelete'; // If marker needs to exist on map even when hidden
+            var markerAlwaysShown = marker._icon && marker.data.immunityLevel == 'alwaysShow'; // If marker should be shown always
 
             // if marker in viewport
             if (pixelBounds.contains(markerPos)) {
                 if (groupClass != 'HIDDEN' && markerState != groupClass) {
+                    if (persistMarkerNode) {
+                        marker._icon.style.display = 'block';
+                    }
+
                     if (!marker._map) {
                         this._map.addLayer(marker);
                     }
 
-                    if (markerState != groupClass) {
+                    if (marker._icon && markerState != groupClass) {
                         if (markerState && markerState != 'HIDDEN') {
                             L.DomUtil.removeClass(marker._icon, markerState);
                         }
@@ -1000,8 +1007,12 @@ L.MarkerGeneralizeGroup = L.FeatureGroup.extend({
                 groupClass = 'HIDDEN';
             }
 
-            if (groupClass == 'HIDDEN' && marker._map) {
-                this._map.removeLayer(marker);
+            if (groupClass == 'HIDDEN' && marker._map && !markerAlwaysShown) {
+                if (persistMarkerNode) {
+                    marker._icon.style.display = 'none';
+                } else {
+                    this._map.removeLayer(marker);
+                }
             }
 
             marker.options.state = groupClass;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,6 +5,8 @@ var concat = require('gulp-concat');
 gulp.task('default', function() {
     gulp.src([
         'src/rbush.js',
+        'src/MarkerClassList.js',
+        'src/ExtendedMarker.js',
         'src/Generalize.js'
     ])
         .pipe(concat('generalize.src.js'))

--- a/src/ExtendedMarker.js
+++ b/src/ExtendedMarker.js
@@ -1,0 +1,74 @@
+/**
+ * Extended marker:
+ * - has options to prevent deletion or hide during generalization
+ * - makes use of internal class list being applied to icon node
+ */
+L.MarkerEx = L.Marker.extend({
+    /**
+     * If we can use extended powers of current marker.
+     */
+    _extended: true,
+
+    /**
+     * Augment parent method to apply class names when icon is added on map
+     * @param map
+     */
+    onAdd: function (map) {
+        L.Marker.prototype.onAdd.apply(this, arguments);
+
+        if (this._immunityLevel == this.IMMUNITY.NO_DELETE) {
+            this._icon.style.display = 'block';
+        }
+
+        this.classes._addClasses();
+    },
+
+    /**
+     * Determine removal possibility and hide marker if required.
+     * @returns {boolean} If marker should be removed from map
+     */
+    onBeforeRemove: function() {
+        if (this._immunityLevel == this.IMMUNITY.NO_HIDE) {
+            return false;
+        }
+
+        if (this._immunityLevel == this.IMMUNITY.NO_DELETE) {
+            this._icon.style.display = 'none';
+            return false;
+        }
+
+        return true;
+    },
+
+    initialize: function() {
+        L.Marker.prototype.initialize.apply(this, arguments);
+        this.classes = L.markerClassList(this);
+    },
+
+    /**
+     * Marker immunity mechanism
+     */
+    IMMUNITY: {
+        NONE: 0, // Simple marker
+        NO_DELETE: 1, // Will stay on map during generalization (DOM node of the icon will not be deleted).
+        NO_HIDE: 2 // Will not be neither deleted nor hidden during generalization.
+    },
+    _immunityLevel: null,
+    immunifyForDeletion: function() {
+        this._immunityLevel = this.IMMUNITY.NO_DELETE;
+        return this;
+    },
+    immunifyForHide: function() {
+        this._immunityLevel = this.IMMUNITY.NO_HIDE;
+        return this;
+    },
+    revokeImmunity: function() {
+        this._immunityLevel = this.IMMUNITY.NONE;
+        return this;
+    }
+});
+
+L.markerEx = function (latlng, options) {
+    return new L.MarkerEx(latlng, options);
+};
+

--- a/src/ExtendedMarker.js
+++ b/src/ExtendedMarker.js
@@ -10,6 +10,11 @@ L.MarkerEx = L.Marker.extend({
     _extended: true,
 
     /**
+     * Do not consider this marker in generalization
+     */
+    _generalizationImmune: false,
+
+    /**
      * Augment parent method to apply class names when icon is added on map
      * @param map
      */
@@ -65,6 +70,9 @@ L.MarkerEx = L.Marker.extend({
     revokeImmunity: function() {
         this._immunityLevel = this.IMMUNITY.NONE;
         return this;
+    },
+    generalizationImmunity: function() {
+        this._generalizationImmune = true;
     }
 });
 

--- a/src/ExtendedMarker.js
+++ b/src/ExtendedMarker.js
@@ -9,10 +9,6 @@ L.MarkerEx = L.Marker.extend({
      */
     _extended: true,
 
-    /**
-     * Do not consider this marker in generalization
-     */
-    _generalizationImmune: false,
 
     /**
      * Augment parent method to apply class names when icon is added on map
@@ -70,9 +66,6 @@ L.MarkerEx = L.Marker.extend({
     revokeImmunity: function() {
         this._immunityLevel = this.IMMUNITY.NONE;
         return this;
-    },
-    generalizationImmunity: function() {
-        this._generalizationImmune = true;
     }
 });
 

--- a/src/ExtendedMarker.js
+++ b/src/ExtendedMarker.js
@@ -15,6 +15,9 @@ L.MarkerEx = L.Marker.extend({
      * @param map
      */
     onAdd: function (map) {
+
+        this._zoomAnimated = false;
+
         L.Marker.prototype.onAdd.apply(this, arguments);
 
         if (this._immunityLevel == this.IMMUNITY.NO_DELETE) {

--- a/src/Generalize.js
+++ b/src/Generalize.js
@@ -233,36 +233,27 @@ L.MarkerGeneralizeGroup = L.FeatureGroup.extend({
                 return;
             }
 
-            var markersInBucket = 1000;
             var totalMarkesCount = seekMarkers.length;
-            var iterationsCount = Math.ceil(totalMarkesCount / markersInBucket);
 
-            L.Util.UnblockingFor(processBucket, iterationsCount, onBucketFinish);
+            for (var i = 0; i < totalMarkesCount; i++) {
+                if (that.options.checkMarkerMinimumLevel(seekMarkers[i]) <= levelIndex) {
+                    currentMarker = makeNode(seekMarkers[i], currentLevel);
+                    items = tree.search(currentMarker);
 
-            function processBucket(bucketIndex, markersCallback) {
-                for (var i = markersInBucket * bucketIndex; i < markersInBucket * (bucketIndex + 1) && i < totalMarkesCount; i++) {
-                    if (that.options.checkMarkerMinimumLevel(seekMarkers[i]) <= levelIndex) {
-                        currentMarker = makeNode(seekMarkers[i], currentLevel);
-                        items = tree.search(currentMarker);
-
-                        if (that._validateGroup(currentMarker, items)) {
-                            tree.insert(currentMarker);
-                            tmpMarkers[levelIndex].push(seekMarkers[i]);
-                        } else {
-                            pendingMarkers.push(seekMarkers[i]);
-                        }
+                    if (that._validateGroup(currentMarker, items)) {
+                        tree.insert(currentMarker);
+                        tmpMarkers[levelIndex].push(seekMarkers[i]);
                     } else {
                         pendingMarkers.push(seekMarkers[i]);
                     }
+                } else {
+                    pendingMarkers.push(seekMarkers[i]);
                 }
-                markersCallback();
             }
 
-            function onBucketFinish() {
-                seekMarkers = pendingMarkers.slice();
-                pendingMarkers = [];
-                levelsCallback();
-            }
+            seekMarkers = pendingMarkers.slice();
+            pendingMarkers = [];
+            levelsCallback();
         }
 
         function updateMarkerStyles() {

--- a/src/Generalize.js
+++ b/src/Generalize.js
@@ -368,15 +368,22 @@ L.MarkerGeneralizeGroup = L.FeatureGroup.extend({
             var groupClass = marker.options.classForZoom[zoom];
             var markerPos = marker._positions[zoom];
             var markerState = marker.options.state;
+            // Immunity levels
+            var persistMarkerNode = marker._icon && marker.data.immunityLevel == 'doNotDelete'; // If marker needs to exist on map even when hidden
+            var markerAlwaysShown = marker._icon && marker.data.immunityLevel == 'alwaysShow'; // If marker should be shown always
 
             // if marker in viewport
             if (pixelBounds.contains(markerPos)) {
                 if (groupClass != 'HIDDEN' && markerState != groupClass) {
+                    if (persistMarkerNode) {
+                        marker._icon.style.display = 'block';
+                    }
+
                     if (!marker._map) {
                         this._map.addLayer(marker);
                     }
 
-                    if (markerState != groupClass) {
+                    if (marker._icon && markerState != groupClass) {
                         if (markerState && markerState != 'HIDDEN') {
                             L.DomUtil.removeClass(marker._icon, markerState);
                         }
@@ -387,8 +394,12 @@ L.MarkerGeneralizeGroup = L.FeatureGroup.extend({
                 groupClass = 'HIDDEN';
             }
 
-            if (groupClass == 'HIDDEN' && marker._map) {
-                this._map.removeLayer(marker);
+            if (groupClass == 'HIDDEN' && marker._map && !markerAlwaysShown) {
+                if (persistMarkerNode) {
+                    marker._icon.style.display = 'none';
+                } else {
+                    this._map.removeLayer(marker);
+                }
             }
 
             marker.options.state = groupClass;

--- a/src/Generalize.js
+++ b/src/Generalize.js
@@ -368,22 +368,20 @@ L.MarkerGeneralizeGroup = L.FeatureGroup.extend({
             var groupClass = marker.options.classForZoom[zoom];
             var markerPos = marker._positions[zoom];
             var markerState = marker.options.state;
-            // Immunity levels
-            var persistMarkerNode = marker._icon && marker.data.immunityLevel == 'doNotDelete'; // If marker needs to exist on map even when hidden
-            var markerAlwaysShown = marker._icon && marker.data.immunityLevel == 'alwaysShow'; // If marker should be shown always
+
+            if (marker._immunityLevel && !marker._map) {
+                // Add immuned markers immediately
+                this._map.addLayer(marker);
+            }
 
             // if marker in viewport
             if (pixelBounds.contains(markerPos)) {
                 if (groupClass != 'HIDDEN' && markerState != groupClass) {
-                    if (persistMarkerNode) {
-                        marker._icon.style.display = 'block';
-                    }
-
                     if (!marker._map) {
                         this._map.addLayer(marker);
                     }
 
-                    if (marker._icon && markerState != groupClass) {
+                    if (markerState != groupClass) {
                         if (markerState && markerState != 'HIDDEN') {
                             L.DomUtil.removeClass(marker._icon, markerState);
                         }
@@ -394,10 +392,8 @@ L.MarkerGeneralizeGroup = L.FeatureGroup.extend({
                 groupClass = 'HIDDEN';
             }
 
-            if (groupClass == 'HIDDEN' && marker._map && !markerAlwaysShown) {
-                if (persistMarkerNode) {
-                    marker._icon.style.display = 'none';
-                } else {
+            if (groupClass == 'HIDDEN') {
+                if (!marker.onBeforeRemove || (marker.onBeforeRemove && marker.onBeforeRemove())) {
                     this._map.removeLayer(marker);
                 }
             }

--- a/src/Generalize.js
+++ b/src/Generalize.js
@@ -133,6 +133,7 @@ L.MarkerGeneralizeGroup = L.FeatureGroup.extend({
 
         var oldMap = this._map;
 
+        // Don't allow markers to be added to map: we'll do it during invalidation.
         if (oldMap) {
             this._map = null;
         }

--- a/src/Generalize.js
+++ b/src/Generalize.js
@@ -226,9 +226,6 @@ L.MarkerGeneralizeGroup = L.FeatureGroup.extend({
 
         for (i = 0; i < this._otherMarkers.length; i++) {
             currentMarker = this._otherMarkers[i];
-            if (currentMarker._immunityLevel) {
-                continue;
-            }
             seekMarkers.push(currentMarker);
         }
 
@@ -236,7 +233,7 @@ L.MarkerGeneralizeGroup = L.FeatureGroup.extend({
 
         function processAllMarkers(levelIndex, levelsCallback) {
             var pendingMarkers = [];
-            var totalMarkesCount = seekMarkers.length;
+            var totalMarkersCount = seekMarkers.length;
             currentLevel = levels[levelIndex];
 
             if (levels[levelIndex].size[0] == 0 && levels[levelIndex].size[1] == 0) {
@@ -244,7 +241,7 @@ L.MarkerGeneralizeGroup = L.FeatureGroup.extend({
                 return;
             }
 
-            for (var i = 0; i < totalMarkesCount; i++) {
+            for (var i = 0; i < totalMarkersCount; i++) {
                 var currentMarker = seekMarkers[i];
 
                 if (that.options.checkMarkerMinimumLevel(currentMarker) <= levelIndex) {
@@ -378,9 +375,14 @@ L.MarkerGeneralizeGroup = L.FeatureGroup.extend({
             var markerPos = marker._positions[zoom];
             var markerState = marker.options.state;
 
-            if (marker._immunityLevel && !marker._map) {
-                // Add immuned markers immediately
-                this._map.addLayer(marker);
+            if (marker._immunityLevel) {
+                if (!marker._map) {
+                    this._map.addLayer(marker);
+                }
+
+                if (markerState != groupClass && groupClass != 'HIDDEN') {
+                    L.DomUtil.addClass(marker._icon, groupClass);
+                }
             }
 
             // if marker in viewport
@@ -406,7 +408,6 @@ L.MarkerGeneralizeGroup = L.FeatureGroup.extend({
                     this._map.removeLayer(marker);
                 }
             }
-
             marker.options.state = groupClass;
         }, this);
 
@@ -419,7 +420,7 @@ L.MarkerGeneralizeGroup = L.FeatureGroup.extend({
 
     addLayer: function(layer) {
         this._addLayer(layer);
-        if (this._map) {
+        if (this._map && !layer._immunityLevel) {
             this._prepareMarker(layer);
             this._calculateMarkersClassForEachZoom();
             this._invalidateMarkers();

--- a/src/Generalize.js
+++ b/src/Generalize.js
@@ -222,7 +222,15 @@ L.MarkerGeneralizeGroup = L.FeatureGroup.extend({
         }
 
         var items,
-            seekMarkers = this._otherMarkers.slice();
+            seekMarkers = [];
+
+        for (i = 0; i < this._otherMarkers.length; i++) {
+            currentMarker = this._otherMarkers[i];
+            if (currentMarker._generalizationImmune) {
+                continue;
+            }
+            seekMarkers.push(currentMarker);
+        }
 
         L.Util.UnblockingFor(processAllMarkers, levels.length, zoomReady);
 

--- a/src/Generalize.js
+++ b/src/Generalize.js
@@ -226,7 +226,7 @@ L.MarkerGeneralizeGroup = L.FeatureGroup.extend({
 
         for (i = 0; i < this._otherMarkers.length; i++) {
             currentMarker = this._otherMarkers[i];
-            if (currentMarker._generalizationImmune) {
+            if (currentMarker._immunityLevel) {
                 continue;
             }
             seekMarkers.push(currentMarker);

--- a/src/MarkerClassList.js
+++ b/src/MarkerClassList.js
@@ -27,13 +27,12 @@ L.Util.extend(L.MarkerClassList.prototype, {
         return !!this._classList[className];
     },
     clear: function() {
+        if (this._marker._icon) {
+                for (var className in this._classList) {
+                    L.DomUtil.removeClass(this._marker._icon, className);
+                }
+        }
         this._classList = {};
-        if (!this._marker._icon) {
-            return;
-        }
-        for (var className in this._classList) {
-            L.DomUtil.removeClass(this._marker._icon, className);
-        }
     },
     toString: function() {
         if (Object.keys) {

--- a/src/MarkerClassList.js
+++ b/src/MarkerClassList.js
@@ -27,13 +27,13 @@ L.Util.extend(L.MarkerClassList.prototype, {
         return !!this._classList[className];
     },
     clear: function() {
+        this._classList = {};
         if (!this._marker._icon) {
             return;
         }
         for (var className in this._classList) {
             L.DomUtil.removeClass(this._marker._icon, className);
         }
-        this._classList = {};
     },
     toString: function() {
         if (Object.keys) {

--- a/src/MarkerClassList.js
+++ b/src/MarkerClassList.js
@@ -1,0 +1,61 @@
+/**
+ * Icon internal classes mechanism
+ * Adds possibility to assign css classes to icon even if it is not rendered (yet).
+ * Classes will be assigned to icon when it is rendered.
+ */
+L.MarkerClassList = function(marker) {
+    this._classList = {};
+    this._marker = marker;
+};
+
+L.Util.extend(L.MarkerClassList.prototype, {
+    add: function(className) {
+        this._classList[className] = 1;
+        if (this._marker._icon) {
+            L.DomUtil.addClass(this._marker._icon, className);
+        }
+        return this;
+    },
+    remove: function(className) {
+        delete this._classList[className];
+        if (this._marker._icon) {
+            L.DomUtil.removeClass(this._marker._icon, className);
+        }
+        return this;
+    },
+    contains: function(className) {
+        return !!this._classList[className];
+    },
+    clear: function() {
+        if (!this._marker._icon) {
+            return;
+        }
+        for (var className in this._classList) {
+            L.DomUtil.removeClass(this._marker._icon, className);
+        }
+        this._classList = {};
+    },
+    toString: function() {
+        if (Object.keys) {
+            return Object.keys(this._classList).join(' ');
+        } else {
+            var classList = '';
+            for (var i in this._classList) {
+                classList += i +' ';
+            }
+        }
+    },
+    _addClasses: function() {
+        if (!this._marker._icon) {
+            return;
+        }
+        for (var className in this._classList) {
+            L.DomUtil.addClass(this._marker._icon, className);
+        }
+    }
+});
+
+L.markerClassList = function (marker) {
+    return new L.MarkerClassList(marker);
+};
+


### PR DESCRIPTION
Left in DOM only shown markers.
- add markers to map only after invalidation
- use getEvents function
- invlidate on moveend. remove dragend,zoomend listeners
- calculate all markers in one loop for one level (not use L.Util.UnblockingFor for this)
- set marker style in main instead separate function

Now first 'invalidate' is 5-7x faster and complete calculation is 3-4x faster
Numbers of DOM nodes reduced dramattically.
